### PR TITLE
clean package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "test": "node test.js"
   },
   "keywords": [
-    "css,px,style,pixel,value"
+    "css", "px", "style", "pixel", "value"
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/mikkoh/add-px-to-style.git"
+    "url": "git://github.com/Jam3/add-px-to-style.git"
   },
-  "homepage": "https://github.com/mikkoh/add-px-to-style",
+  "homepage": "https://github.com/Jam3/add-px-to-style",
   "bugs": {
-    "url": "https://github.com/mikkoh/add-px-to-style/issues"
+    "url": "https://github.com/Jam3/add-px-to-style/issues"
   }
 }


### PR DESCRIPTION
- repo url was wrong
- package.json keywords were not separate

Try updating to latest `module-generator` and `ghrepo` modules, it should help with team modules.

``` sh
cd my-module

# use Jam3 license + repo URLs
module-generator -u Jam3

# it will know to push to Jam3/my-module
ghrepo
```
